### PR TITLE
Added support for switching main view and commands

### DIFF
--- a/src/Guit.Tests/Misc.cs
+++ b/src/Guit.Tests/Misc.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Linq;
 using LibGit2Sharp;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,6 +16,8 @@ namespace Guit.Tests
         {
             using (var repo = new Repository(@"..\..\..\.."))
             {
+                var plugins = repo.Config.OfType<ConfigurationEntry<string>>().Where(x => x.Key == "guit.plugin").ToArray();
+
                 output.WriteLine(repo.Branches.ToString());
 
                 // Object lookup

--- a/src/Guit/App.cs
+++ b/src/Guit/App.cs
@@ -1,23 +1,46 @@
 ﻿using System.Collections.Generic;
 using System.Composition;
-using Guit.Plugin.Changes;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Guit.Plugin;
+using LibGit2Sharp;
 using Terminal.Gui;
 
 namespace Guit
 {
     [Export]
-    public class App : Toplevel
+    [Export(typeof(IApp))]
+    [Shared]
+    internal class App : Toplevel, IApp
     {
+        Window main;
+
         [ImportingConstructor]
         public App(
-            ChangesView mainWindow, 
-            //StatusBar status, 
-            // Just importing the singletons causes them to be instantiated.
+            // Force a RepositoryNotFoundException up-front.
+            Repository repository, 
+            [ImportMany] IEnumerable<MainView> views,
+            // Force all singletons to be instantiated.
             [ImportMany] IEnumerable<ISingleton> singletons)
         {
-            //status.Y = Pos.Bottom(mainWindow);
-            //mainWindow.Height = Height - status.Height;
-            Add(mainWindow);
+            // Show an error window if we did not get at least one MainView.
+            main = views.FirstOrDefault() ?? new Window("No MainView found!")
+            {
+                ColorScheme = Colors.Error,
+            };
+        }
+
+        // Run the main window as soon as the app is presented.
+        public override void WillPresent() => RunAsync(main);
+
+        Task IApp.RunAsync(MainView view, CancellationToken cancellation) => RunAsync(view, cancellation);
+
+        private Task RunAsync(Window view, CancellationToken cancellation = default)
+        {
+            main.Running = false;
+            main = view;
+            return Task.Run(() => Application.MainLoop.Invoke(() => Application.Run(view)), cancellation);
         }
     }
 }

--- a/src/Guit/App.cs
+++ b/src/Guit/App.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
-using System.Threading;
-using Guit.Events;
-using Merq;
+using Guit.Plugin.Changes;
 using Terminal.Gui;
 
 namespace Guit
@@ -12,51 +8,16 @@ namespace Guit
     [Export]
     public class App : Toplevel
     {
-        readonly IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> menuCommands;
-
         [ImportingConstructor]
         public App(
-            CommitView mainWindow, 
-            StatusBar status, 
-            [ImportMany] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> menuCommands,
+            ChangesView mainWindow, 
+            //StatusBar status, 
             // Just importing the singletons causes them to be instantiated.
             [ImportMany] IEnumerable<ISingleton> singletons)
         {
-            this.menuCommands = menuCommands;
-            var commands = new View
-            {
-                Y = Pos.Bottom(mainWindow),
-                Height = 1
-            };
-
-            View current = new Label("");
-            commands.Add(current);
-            foreach (var command in menuCommands.OrderBy(x => x.Metadata.Order))
-            {
-                current = new Button(command.Metadata.HotKey + " " + command.Metadata.DisplayName)
-                {
-                    CanFocus = false,
-                    X = Pos.Right(current),
-                    // TODO: improve execution, cancellation, etc.
-                    Clicked = () => command.Value.ExecuteAsync(CancellationToken.None),
-                };
-                commands.Add(current);
-            }
-
-            status.Y = Pos.Bottom(commands);
-            mainWindow.Height = Height - commands.Height - status.Height;
-
-            Add(mainWindow, commands, status);
-            singletons.ToList();
-        }
-
-        public override bool ProcessHotKey(KeyEvent keyEvent)
-        {
-            var command = menuCommands.FirstOrDefault(x => keyEvent.Key == x.Metadata.HotKey);
-            if (command != null)
-                command.Value.ExecuteAsync(CancellationToken.None);
-
-            return base.ProcessHotKey(keyEvent);
+            //status.Y = Pos.Bottom(mainWindow);
+            //mainWindow.Height = Height - status.Height;
+            Add(mainWindow);
         }
     }
 }

--- a/src/Guit/Commands/FetchCommand.cs
+++ b/src/Guit/Commands/FetchCommand.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Guit.Events;
-using Guit.Properties;
 using LibGit2Sharp;
 using Merq;
 using Terminal.Gui;
@@ -12,7 +11,7 @@ using Git = LibGit2Sharp.Commands;
 namespace Guit.Commands
 {
     [Shared]
-    [MenuCommand(nameof(Resources.FetchDisplayName), Key.F6)]
+    [MenuCommand("Fetch", Key.F6, nameof(Plugin.Sync))]
     public class FetchCommand : IMenuCommand
     {
         readonly Repository repository;

--- a/src/Guit/Commands/ViewCommand.cs
+++ b/src/Guit/Commands/ViewCommand.cs
@@ -4,14 +4,13 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Guit.Properties;
 using LibGit2Sharp;
 using Terminal.Gui;
 
 namespace Guit.Commands
 {
     [Shared]
-    [MenuCommand(nameof(Resources.ViewDisplayName), Key.F4)]
+    [MenuCommand("View", Key.F4)]
     public class ViewCommand : IMenuCommand
     {
         readonly Repository repository;

--- a/src/Guit/Core/MenuCommandAttribute.cs
+++ b/src/Guit/Core/MenuCommandAttribute.cs
@@ -11,21 +11,22 @@ namespace Guit
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class MenuCommandAttribute : ExportAttribute
     {
-        public MenuCommandAttribute(string displayNameResource, Key hotKey) :
-            this(displayNameResource, hotKey, (double)hotKey)
+        public MenuCommandAttribute(string id, Key hotKey, string context = null) :
+            this(id, hotKey, (double)hotKey, context)
         {
         }
 
-        public MenuCommandAttribute(string displayNameResource, Key hotKey, double order) : base(typeof(IMenuCommand))
+        public MenuCommandAttribute(string id, Key hotKey, double order, string context = null) 
+            : base(context, typeof(IMenuCommand))
         {
             var resourceManager = new ResourceManager(typeof(Resources));
             try
             {
-                DisplayName = resourceManager.GetString(displayNameResource, CultureInfo.CurrentUICulture);
+                DisplayName = resourceManager.GetString(id, CultureInfo.CurrentUICulture) ?? id;
             }
             catch (MissingManifestResourceException)
             {
-                DisplayName = displayNameResource;
+                DisplayName = id;
             }
 
             HotKey = hotKey;

--- a/src/Guit/Guit.targets
+++ b/src/Guit/Guit.targets
@@ -18,6 +18,7 @@ AssemblyVersion=$(AssemblyVersion)" />
           Condition="'$(GitInfoImported)' == 'true' And '$(ExcludeRestorePackageImports)' != 'true'">
 
     <PropertyGroup>
+      <GitBranch>$(GitBranch.Replace('/', '-'))</GitBranch>
       <!-- We don't build stable versions from non-master branches. But when the version came from the branch, we leave it as-is. -->
       <GitSemVerDashLabel Condition="'$(GitBranch)' != 'master' and '$(GitSemVerDashLabel)' == '' and '$(GitSemVerSource)' != 'Branch'">-$(GitBranch)</GitSemVerDashLabel>
     </PropertyGroup>

--- a/src/Guit/IApp.cs
+++ b/src/Guit/IApp.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Guit.Plugin;
+
+namespace Guit
+{
+    /// <summary>
+    /// Allows commands to run main views, which cause the current main view 
+    /// to be closed and the new one showed.
+    /// </summary>
+    public interface IApp
+    {
+        /// <summary>
+        /// Runs the given main view as the top-level view in the app.
+        /// </summary>
+        Task RunAsync(MainView view, CancellationToken cancellation = default);
+    }
+}

--- a/src/Guit/Plugin/Changes/ChangesCommand.cs
+++ b/src/Guit/Plugin/Changes/ChangesCommand.cs
@@ -1,0 +1,23 @@
+﻿using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Terminal.Gui;
+
+namespace Guit.Plugin.Changes
+{
+    [Shared]
+    [MenuCommand(nameof(Changes), Key.F1)]
+    public class ChangesCommand : IMenuCommand
+    {
+        readonly ChangesView view;
+
+        [ImportingConstructor]
+        public ChangesCommand(ChangesView view) => this.view = view;
+
+        public Task ExecuteAsync(CancellationToken cancellation)
+        {
+            Task.Run(() => Application.Run(view));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Guit/Plugin/Changes/ChangesCommand.cs
+++ b/src/Guit/Plugin/Changes/ChangesCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Composition;
+﻿using System;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Terminal.Gui;
@@ -9,15 +10,11 @@ namespace Guit.Plugin.Changes
     [MenuCommand(nameof(Changes), Key.F1)]
     public class ChangesCommand : IMenuCommand
     {
-        readonly ChangesView view;
+        readonly Func<CancellationToken, Task> run;
 
         [ImportingConstructor]
-        public ChangesCommand(ChangesView view) => this.view = view;
+        public ChangesCommand(ChangesView view, IApp app) => run = cancellation => app.RunAsync(view, cancellation);
 
-        public Task ExecuteAsync(CancellationToken cancellation)
-        {
-            Task.Run(() => Application.Run(view));
-            return Task.CompletedTask;
-        }
+        public Task ExecuteAsync(CancellationToken cancellation) => run(cancellation);
     }
 }

--- a/src/Guit/Plugin/Changes/ChangesView.cs
+++ b/src/Guit/Plugin/Changes/ChangesView.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
-using System.Threading;
 using Guit.Events;
 using LibGit2Sharp;
 using Merq;
@@ -12,6 +11,7 @@ namespace Guit.Plugin.Changes
 {
     [Shared]
     [Export]
+    [Export(typeof(MainView))]
     public class ChangesView : MainView
     {
         readonly IEventStream eventStream;

--- a/src/Guit/Plugin/Changes/ChangesView.cs
+++ b/src/Guit/Plugin/Changes/ChangesView.cs
@@ -2,23 +2,30 @@
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
+using System.Threading;
 using Guit.Events;
 using LibGit2Sharp;
 using Merq;
 using Terminal.Gui;
 
-namespace Guit
+namespace Guit.Plugin.Changes
 {
     [Shared]
     [Export]
-    public class CommitView : FrameView
+    public class ChangesView : MainView
     {
         readonly IEventStream eventStream;
+
         readonly List<FileStatus> files;
         readonly ListView view;
 
         [ImportingConstructor]
-        public CommitView(Repository repository, IEventStream eventStream) : base("Changes")
+        public ChangesView(
+            Repository repository,
+            IEventStream eventStream,
+            [ImportMany] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> globalCommands,
+            [ImportMany(nameof(Changes))] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> localCommands)
+            : base("Changes", globalCommands, localCommands)
         {
             this.eventStream = eventStream;
 
@@ -35,10 +42,8 @@ namespace Guit
                 AllowsMarking = true,
             };
             view.SelectedChanged += OnSelectedChanged;
-            Add(view);
 
-            Width = Dim.Fill();
-            Height = Dim.Fill();
+            Content = view;
         }
 
         void OnSelectedChanged()

--- a/src/Guit/Plugin/Changes/CommitCommand.cs
+++ b/src/Guit/Plugin/Changes/CommitCommand.cs
@@ -1,0 +1,25 @@
+﻿using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Guit.Events;
+using Merq;
+using Terminal.Gui;
+
+namespace Guit.Plugin.Changes
+{
+    [Shared]
+    [MenuCommand("Commit", Key.F6, nameof(Changes))]
+    public class CommitCommand : IMenuCommand
+    {
+        IEventStream eventStream;
+
+        [ImportingConstructor]
+        public CommitCommand(IEventStream eventStream) => this.eventStream = eventStream;
+
+        public Task ExecuteAsync(CancellationToken cancellation)
+        {
+            eventStream.Push<StatusUpdated>("Committed!");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Guit/Plugin/Log/LogCommand.cs
+++ b/src/Guit/Plugin/Log/LogCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Composition;
+﻿using System;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Terminal.Gui;
@@ -9,15 +10,11 @@ namespace Guit.Plugin.Log
     [MenuCommand(nameof(Log), Key.F3)]
     public class LogCommand : IMenuCommand
     {
-        readonly LogView view;
+        readonly Func<CancellationToken, Task> run;
 
         [ImportingConstructor]
-        public LogCommand(LogView view) => this.view = view;
+        public LogCommand(LogView view, IApp app) => run = cancellation => app.RunAsync(view, cancellation);
 
-        public Task ExecuteAsync(CancellationToken cancellation)
-        {
-            Task.Run(() => Application.Run(view));
-            return Task.CompletedTask;
-        }
+        public Task ExecuteAsync(CancellationToken cancellation) => run(cancellation);
     }
 }

--- a/src/Guit/Plugin/Log/LogCommand.cs
+++ b/src/Guit/Plugin/Log/LogCommand.cs
@@ -1,0 +1,23 @@
+﻿using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Terminal.Gui;
+
+namespace Guit.Plugin.Log
+{
+    [Shared]
+    [MenuCommand(nameof(Log), Key.F3)]
+    public class LogCommand : IMenuCommand
+    {
+        readonly LogView view;
+
+        [ImportingConstructor]
+        public LogCommand(LogView view) => this.view = view;
+
+        public Task ExecuteAsync(CancellationToken cancellation)
+        {
+            Task.Run(() => Application.Run(view));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Guit/Plugin/Log/LogView.cs
+++ b/src/Guit/Plugin/Log/LogView.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition;
+using Terminal.Gui;
+
+namespace Guit.Plugin.Log
+{
+    [Shared]
+    [Export]
+    public class LogView : MainView
+    {
+        [ImportingConstructor]
+        public LogView(
+            [ImportMany] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> globalCommands,
+            [ImportMany(nameof(Log))] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> localCommands)
+            : base("Log", globalCommands, localCommands)
+        {
+            Content = new View
+            {
+                new Label("// TODO: Log")
+            };
+        }
+    }
+}

--- a/src/Guit/Plugin/MainView.cs
+++ b/src/Guit/Plugin/MainView.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Terminal.Gui;
+
+namespace Guit.Plugin
+{
+    public abstract class MainView : Window
+    {
+        readonly IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> globalCommands;
+        readonly IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> localCommands;
+
+        readonly View commandsView;
+
+        public MainView(
+            string title,
+            [ImportMany] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> globalCommands,
+            [ImportMany(nameof(Changes))] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> localCommands)
+            : base(title)
+        {
+            this.globalCommands = globalCommands;
+            this.localCommands = localCommands;
+
+            Width = Dim.Fill();
+            Height = Dim.Fill();
+
+            // Seems like a bug in gui.cs since both are set with a margin of 2, 
+            // which is 1 unnecessary extra value since X,Y are already 1.
+            var contentView = Subviews[0];
+            contentView.Width = Dim.Fill(1);
+            contentView.Height = Dim.Fill(1);
+            
+            commandsView = new View
+            {
+                Height = 1
+            };
+
+            var globals = new View();
+            var spacer = new Label("||") { X = Pos.Right(globals), TextAlignment = TextAlignment.Centered };
+            var locals = new View { X = Pos.Right(spacer) };
+
+            spacer.Width = Dim.Width(this) - 2 - Dim.Width(globals) - Dim.Width(locals);
+            commandsView.Add(globals, spacer, locals);
+
+            View current = new Label("");
+            globals.Add(current);
+            globals.Width = Dim.Width(current);
+            foreach (var command in globalCommands.OrderBy(x => x.Metadata.Order))
+            {
+                current = new Button(command.Metadata.HotKey + " " + command.Metadata.DisplayName)
+                {
+                    CanFocus = false,
+                    X = Pos.Right(current),
+                    // TODO: improve execution, cancellation, etc.
+                    Clicked = () => command.Value.ExecuteAsync(CancellationToken.None),
+                };
+                globals.Add(current);
+                // Not sure why we need to do this... seems like the containing view 
+                // width should equal the width of its subviews automatically unless 
+                // a different width is specified... 
+                globals.Width += Dim.Width(current);
+            }
+
+            current = new Label("");
+            locals.Add(current);
+            locals.Width = Dim.Width(current);
+            foreach (var command in localCommands.OrderBy(x => x.Metadata.Order))
+            {
+                current = new Button(command.Metadata.HotKey + " " + command.Metadata.DisplayName)
+                {
+                    CanFocus = false,
+                    X = Pos.Right(current),
+                    // TODO: improve execution, cancellation, etc.
+                    Clicked = () => command.Value.ExecuteAsync(CancellationToken.None),
+                };
+                locals.Add(current);
+                locals.Width += Dim.Width(current);
+            }
+        }
+
+        protected View Content
+        {
+            set
+            {
+                commandsView.Y = Pos.Bottom(value);
+                value.Height = Height - 1;
+                Add(value, commandsView);
+                LayoutSubviews();
+            }
+        }
+
+        public override bool ProcessHotKey(KeyEvent keyEvent)
+        {
+            var command = localCommands.FirstOrDefault(x => keyEvent.Key == x.Metadata.HotKey) ??
+                globalCommands.FirstOrDefault(x => keyEvent.Key == x.Metadata.HotKey);
+
+            if (command != null)
+            {
+                command.Value.ExecuteAsync(CancellationToken.None);
+                return true;
+            }
+
+            return base.ProcessHotKey(keyEvent);
+        }
+    }
+}

--- a/src/Guit/Plugin/MainView.cs
+++ b/src/Guit/Plugin/MainView.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using Terminal.Gui;
 

--- a/src/Guit/Plugin/Sync/PullCommand.cs
+++ b/src/Guit/Plugin/Sync/PullCommand.cs
@@ -2,14 +2,13 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Guit.Events;
-using Guit.Properties;
 using Merq;
 using Terminal.Gui;
 
-namespace Guit.Commands
+namespace Guit.Plugin.Sync
 {
     [Shared]
-    [MenuCommand(nameof(Resources.PullDisplayName), Key.F5)]
+    [MenuCommand("Sync.Pull", Key.F7, nameof(Sync))]
     public class PullCommand : IMenuCommand
     {
         IEventStream eventStream;

--- a/src/Guit/Plugin/Sync/SyncCommand.cs
+++ b/src/Guit/Plugin/Sync/SyncCommand.cs
@@ -1,0 +1,25 @@
+﻿using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Guit.Events;
+using Merq;
+using Terminal.Gui;
+
+namespace Guit.Plugin.Sync
+{
+    [Shared]
+    [MenuCommand(nameof(Sync), Key.F2)]
+    public class SyncCommand : IMenuCommand
+    {
+        readonly SyncView view;
+
+        [ImportingConstructor]
+        public SyncCommand(SyncView view) => this.view = view;
+
+        public Task ExecuteAsync(CancellationToken cancellation)
+        {
+            Task.Run(() => Application.Run(view));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Guit/Plugin/Sync/SyncCommand.cs
+++ b/src/Guit/Plugin/Sync/SyncCommand.cs
@@ -1,8 +1,7 @@
-﻿using System.Composition;
+﻿using System;
+using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Guit.Events;
-using Merq;
 using Terminal.Gui;
 
 namespace Guit.Plugin.Sync
@@ -11,15 +10,11 @@ namespace Guit.Plugin.Sync
     [MenuCommand(nameof(Sync), Key.F2)]
     public class SyncCommand : IMenuCommand
     {
-        readonly SyncView view;
+        readonly Func<CancellationToken, Task> run;
 
         [ImportingConstructor]
-        public SyncCommand(SyncView view) => this.view = view;
+        public SyncCommand(SyncView view, IApp app) => run = cancellation => app.RunAsync(view, cancellation);
 
-        public Task ExecuteAsync(CancellationToken cancellation)
-        {
-            Task.Run(() => Application.Run(view));
-            return Task.CompletedTask;
-        }
+        public Task ExecuteAsync(CancellationToken cancellation) => run(cancellation);
     }
 }

--- a/src/Guit/Plugin/Sync/SyncView.cs
+++ b/src/Guit/Plugin/Sync/SyncView.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition;
+using Terminal.Gui;
+
+namespace Guit.Plugin.Sync
+{
+    [Shared]
+    [Export]
+    public class SyncView : MainView
+    {
+        [ImportingConstructor]
+        public SyncView(
+            [ImportMany] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> globalCommands,
+            [ImportMany(nameof(Sync))] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> localCommands)
+            : base("Sync", globalCommands, localCommands)
+        {
+            Content = new View
+            {
+                new Label("// TODO: Sync")
+            };
+        }
+    }
+}

--- a/src/Guit/Program.cs
+++ b/src/Guit/Program.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Composition.Hosting;
-using Guit.Plugin.Changes;
 using LibGit2Sharp;
 using Terminal.Gui;
 
@@ -18,14 +16,7 @@ namespace Guit
 
                 Application.Init();
 
-                // Force a RepositoryNotFoundException up-front.
-                container.GetExport<Repository>();
-                // Force all singletons to be instantiated.
-                container.GetExports<ISingleton>();
-
-                //var app = container.GetExport<App>();
-                
-                Application.Run(container.GetExport<ChangesView>());
+                container.GetExport<App>().Run();
             }
             catch (RepositoryNotFoundException e)
             {

--- a/src/Guit/Program.cs
+++ b/src/Guit/Program.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Composition.Hosting;
+using Guit.Plugin.Changes;
 using LibGit2Sharp;
 using Terminal.Gui;
 
@@ -18,10 +20,12 @@ namespace Guit
 
                 // Force a RepositoryNotFoundException up-front.
                 container.GetExport<Repository>();
+                // Force all singletons to be instantiated.
+                container.GetExports<ISingleton>();
 
-                var app = container.GetExport<App>();
-
-                Application.Run(app);
+                //var app = container.GetExport<App>();
+                
+                Application.Run(container.GetExport<ChangesView>());
             }
             catch (RepositoryNotFoundException e)
             {

--- a/src/Guit/Properties/Resources.Designer.cs
+++ b/src/Guit/Properties/Resources.Designer.cs
@@ -61,29 +61,11 @@ namespace Guit.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fetch.
-        /// </summary>
-        internal static string FetchDisplayName {
-            get {
-                return ResourceManager.GetString("FetchDisplayName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Pull.
         /// </summary>
-        internal static string PullDisplayName {
+        internal static string Sync_Pull {
             get {
-                return ResourceManager.GetString("PullDisplayName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to View.
-        /// </summary>
-        internal static string ViewDisplayName {
-            get {
-                return ResourceManager.GetString("ViewDisplayName", resourceCulture);
+                return ResourceManager.GetString("Sync.Pull", resourceCulture);
             }
         }
     }

--- a/src/Guit/Properties/Resources.resx
+++ b/src/Guit/Properties/Resources.resx
@@ -117,13 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="FetchDisplayName" xml:space="preserve">
-    <value>Fetch</value>
-  </data>
-  <data name="PullDisplayName" xml:space="preserve">
+  <data name="Sync.Pull" xml:space="preserve">
     <value>Pull</value>
-  </data>
-  <data name="ViewDisplayName" xml:space="preserve">
-    <value>View</value>
   </data>
 </root>


### PR DESCRIPTION
The new base class `MainView` encapsulates the command bar building, so that individual views can just pass along their imported global and local commands. The `context` for the local commands is used as the contract name for filtering.

This is work in progress since we need to move some types to a new `Guit.Plugin` nuget package which can be consumed by the various plugins.

Also, we're currently hardcoding the "main view" on app start, but that should also be contributed by plugins.

There is an example showing `Log` (with no contextual commands) and `Sync` (with `Fetch` and `Pull` contextual commands) to prove the concept.

Partially fixes #5.

![Commands](https://user-images.githubusercontent.com/169707/64587332-6de6fe00-d375-11e9-8246-60054effcbff.gif)
