### PR TITLE
Improve and centralize handling of main thread

### DIFF
--- a/src/Guit/App.cs
+++ b/src/Guit/App.cs
@@ -12,19 +12,17 @@ namespace Guit
     [Export]
     [Export(typeof(IApp))]
     [Shared]
-    internal class App : Toplevel, IApp
+    class App : Toplevel, IApp
     {
         Window main;
+        readonly MainThread mainThread;
         readonly CommandService commandService;
 
         [ImportingConstructor]
         public App(
-            // Force a RepositoryNotFoundException up-front.
-            Repository repository,
-            [ImportMany] IEnumerable<MainView> views,
-            // Force all singletons to be instantiated.
-            [ImportMany] IEnumerable<ISingleton> singletons,
-            CommandService commandsService)
+            [ImportMany] IEnumerable<ContentView> views,
+            MainThread mainThread,
+            CommandService commandService)
         {
             // Show an error window if we did not get at least one MainView.
             main = views.FirstOrDefault() ?? new Window("No MainView found!")
@@ -32,31 +30,34 @@ namespace Guit
                 ColorScheme = Colors.Error,
             };
 
-            this.commandService = commandsService;
+            this.mainThread = mainThread;
+            this.commandService = commandService;
+        }
+
+        public override bool ProcessHotKey(KeyEvent keyEvent)
+        {
+            commandService.RunAsync(keyEvent.KeyValue, (main as ContentView)?.Context);
+
+            return base.ProcessHotKey(keyEvent);
         }
 
         // Run the main window as soon as the app is presented.
         public override void WillPresent() => RunAsync(main);
 
-        Task IApp.RunAsync(MainView view, CancellationToken cancellation) => RunAsync(view, cancellation);
+        Task IApp.RunAsync(ContentView view) => RunAsync(view);
 
-        private Task RunAsync(Window view, CancellationToken cancellation = default)
+        Task RunAsync(Window view)
         {
             main.Running = false;
             main = view;
 
             // Check if the view is a MainView and if the CommandsView was not already set
-            if (main is MainView mainView && mainView != null && mainView.CommandsView == null)
-                mainView.CommandsView = commandService.GetCommandsView(mainView);
+            if (main is ContentView mainView && mainView != null && mainView.Commands == null)
+                mainView.Commands = commandService.GetCommands(mainView);
 
-            return Task.Run(() => Application.MainLoop.Invoke(() => Application.Run(view)), cancellation);
-        }
+            mainThread.Invoke(() => Application.Run(view));
 
-        public override bool ProcessHotKey(KeyEvent keyEvent)
-        {
-            commandService.RunAsync(keyEvent.KeyValue, (main as MainView)?.Context);
-
-            return base.ProcessHotKey(keyEvent);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Guit/Core/IApp.cs
+++ b/src/Guit/Core/IApp.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Guit.Plugin;
 
 namespace Guit
@@ -13,6 +12,6 @@ namespace Guit
         /// <summary>
         /// Runs the given main view as the top-level view in the app.
         /// </summary>
-        Task RunAsync(MainView view, CancellationToken cancellation = default);
+        Task RunAsync(ContentView view);
     }
 }

--- a/src/Guit/Core/MainThread.cs
+++ b/src/Guit/Core/MainThread.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Composition;
+using System.Threading;
+using Terminal.Gui;
+
+namespace Guit
+{
+    /// <summary>
+    /// Ensures the execution of an action happens on the UI thread.
+    /// </summary>
+    [Export]
+    [Shared]
+    public class MainThread
+    {
+        int mainThreadId;
+
+        public MainThread() => mainThreadId = Thread.CurrentThread.ManagedThreadId;
+
+        public void Invoke(Action action)
+        {
+            if (Thread.CurrentThread.ManagedThreadId == mainThreadId)
+                action();
+            else
+                Application.MainLoop.Invoke(action);
+        }
+    }
+}
+    

--- a/src/Guit/DefaultExports.cs
+++ b/src/Guit/DefaultExports.cs
@@ -12,6 +12,7 @@ namespace Guit
     [Shared]
     public class DefaultExports
     {
+        [Export(typeof(ISingleton))]
         [Export]
         public Repository Repository { get; } = new Repository(Directory.GetCurrentDirectory());
 

--- a/src/Guit/Plugin/Changes/ChangesCommand.cs
+++ b/src/Guit/Plugin/Changes/ChangesCommand.cs
@@ -10,11 +10,11 @@ namespace Guit.Plugin.Changes
     [MenuCommand(nameof(Changes), Key.F1)]
     public class ChangesCommand : IMenuCommand
     {
-        readonly Func<CancellationToken, Task> run;
+        readonly Func<Task> run;
 
         [ImportingConstructor]
-        public ChangesCommand(ChangesView view, IApp app) => run = cancellation => app.RunAsync(view, cancellation);
+        public ChangesCommand(ChangesView view, IApp app) => run = () => app.RunAsync(view);
 
-        public Task ExecuteAsync(CancellationToken cancellation) => run(cancellation);
+        public Task ExecuteAsync(CancellationToken cancellation) => run();
     }
 }

--- a/src/Guit/Plugin/Changes/ChangesView.cs
+++ b/src/Guit/Plugin/Changes/ChangesView.cs
@@ -11,8 +11,8 @@ namespace Guit.Plugin.Changes
 {
     [Shared]
     [Export]
-    [Export(typeof(MainView))]
-    public class ChangesView : MainView
+    [Export(typeof(ContentView))]
+    public class ChangesView : ContentView
     {
         readonly IEventStream eventStream;
 

--- a/src/Guit/Plugin/ContentView.cs
+++ b/src/Guit/Plugin/ContentView.cs
@@ -1,19 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Composition;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Terminal.Gui;
+﻿using Terminal.Gui;
 
 namespace Guit.Plugin
 {
-    public abstract class MainView : Window
+    public abstract class ContentView : Window
     {
         View content;
-        View commandsView;
+        View commands;
 
-        public MainView(string title)
+        public ContentView(string title)
             : base(title)
         {
             Width = Dim.Fill();
@@ -21,9 +15,9 @@ namespace Guit.Plugin
             
             // Seems like a bug in gui.cs since both are set with a margin of 2, 
             // which is 1 unnecessary extra value since X,Y are already 1.
-            var contentView = Subviews[0];
-            contentView.Width = Dim.Fill(1);
-            contentView.Height = Dim.Fill(1);
+            var content = Subviews[0];
+            content.Width = Dim.Fill(1);
+            content.Height = Dim.Fill(1);
         }
 
         public virtual string Context => null;
@@ -34,21 +28,20 @@ namespace Guit.Plugin
             set
             {
                 content = value;
-
                 Add(content);
             }
         }
 
-        public View CommandsView
+        internal View Commands
         {
-            get => commandsView;
+            get => commands;
             set
             {
-                commandsView = value;
+                commands = value;
 
-                commandsView.Y = Pos.Bottom(content);
-                content.Height = Height - commandsView.Height;
-                Add(commandsView);
+                commands.Y = Pos.Bottom(content);
+                content.Height = Height - commands.Height;
+                Add(commands);
 
                 LayoutSubviews();
             }

--- a/src/Guit/Plugin/Log/LogCommand.cs
+++ b/src/Guit/Plugin/Log/LogCommand.cs
@@ -10,11 +10,11 @@ namespace Guit.Plugin.Log
     [MenuCommand(nameof(Log), Key.F3)]
     public class LogCommand : IMenuCommand
     {
-        readonly Func<CancellationToken, Task> run;
+        readonly Func<Task> run;
 
         [ImportingConstructor]
-        public LogCommand(LogView view, IApp app) => run = cancellation => app.RunAsync(view, cancellation);
+        public LogCommand(LogView view, IApp app) => run = () => app.RunAsync(view);
 
-        public Task ExecuteAsync(CancellationToken cancellation) => run(cancellation);
+        public Task ExecuteAsync(CancellationToken cancellation) => run();
     }
 }

--- a/src/Guit/Plugin/Log/LogView.cs
+++ b/src/Guit/Plugin/Log/LogView.cs
@@ -7,7 +7,7 @@ namespace Guit.Plugin.Log
 {
     [Shared]
     [Export]
-    public class LogView : MainView
+    public class LogView : ContentView
     {
         [ImportingConstructor]
         public LogView()

--- a/src/Guit/Plugin/Sync/SyncCommand.cs
+++ b/src/Guit/Plugin/Sync/SyncCommand.cs
@@ -10,11 +10,11 @@ namespace Guit.Plugin.Sync
     [MenuCommand(nameof(Sync), Key.F2)]
     public class SyncCommand : IMenuCommand
     {
-        readonly Func<CancellationToken, Task> run;
+        readonly Func<Task> run;
 
         [ImportingConstructor]
-        public SyncCommand(SyncView view, IApp app) => run = cancellation => app.RunAsync(view, cancellation);
+        public SyncCommand(SyncView view, IApp app) => run = () => app.RunAsync(view);
 
-        public Task ExecuteAsync(CancellationToken cancellation) => run(cancellation);
+        public Task ExecuteAsync(CancellationToken cancellation) => run();
     }
 }

--- a/src/Guit/Plugin/Sync/SyncView.cs
+++ b/src/Guit/Plugin/Sync/SyncView.cs
@@ -7,7 +7,7 @@ namespace Guit.Plugin.Sync
 {
     [Shared]
     [Export]
-    public class SyncView : MainView
+    public class SyncView : ContentView
     {
         [ImportingConstructor]
         public SyncView()

--- a/src/Guit/Program.cs
+++ b/src/Guit/Program.cs
@@ -27,17 +27,25 @@ namespace Guit
 
                 Application.Init();
 
+                // Force all singletons to be instantiated.
+                provider.GetExportedValues<ISingleton>();
+
                 AppDomain.CurrentDomain.UnhandledException += (sender, args) => Console.Error.WriteLine(args.ExceptionObject?.ToString());
                 TaskScheduler.UnobservedTaskException += (sender, args) => Console.Error.WriteLine(args.Exception?.ToString());
 
                 // Obtain our first exported value
                 Application.Run(provider.GetExportedValue<App>());
             }
-            catch (RepositoryNotFoundException e)
+            catch (CompositionFailedException e)
             {
                 var color = Console.ForegroundColor;
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.Error.WriteLine(e.Message);
+
+                if (e.InnerException != null)
+                    Console.Error.WriteLine(e.Message);
+                else
+                    Console.Error.WriteLine(e.ToString());
+
                 Console.ForegroundColor = color;
                 return;
             }

--- a/src/Guit/Properties/launchSettings.json
+++ b/src/Guit/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Guit": {
       "commandName": "Project",
-      "workingDirectory": "C:\\GitHub\\Guit"
+      "workingDirectory": "..\\.."
     }
   }
 }


### PR DESCRIPTION
When performing work that is intended to run on the main thread
is already on the main thread, we should avoid using `Task.Run`
since that results in very slow interactions from that point on
for the resulting UIs.