### PR TITLE
Change JTF for MainThread

### DIFF
--- a/src/Guit/Core/MainThread.cs
+++ b/src/Guit/Core/MainThread.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Composition;
 using System.Threading;
+using System.Threading.Tasks;
 using Terminal.Gui;
 
 namespace Guit
@@ -22,6 +23,29 @@ namespace Guit
                 action();
             else
                 Application.MainLoop.Invoke(action);
+        }
+
+        public T Invoke<T>(Func<T> function)
+        {
+            if (Thread.CurrentThread.ManagedThreadId == mainThreadId)
+            {
+                return function();
+            }
+            else
+            {
+                // Run and wait for a result.
+                var ev = new ManualResetEventSlim();
+                T result = default;
+
+                Application.MainLoop.Invoke(() =>
+                {
+                    result = function();
+                    ev.Set();
+                });
+
+                ev.Wait();
+                return result;
+            }
         }
     }
 }

--- a/src/Guit/DefaultExports.cs
+++ b/src/Guit/DefaultExports.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Composition;
 using System.IO;
-using System.Threading;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 using Microsoft.Alm.Authentication;
-using Microsoft.VisualStudio.Threading;
 
 namespace Guit
 {
@@ -15,12 +13,6 @@ namespace Guit
         [Export(typeof(ISingleton))]
         [Export]
         public Repository Repository { get; } = new Repository(Directory.GetCurrentDirectory());
-
-        [Export]
-        public JoinableTaskFactory TaskFactory { get; } = new JoinableTaskFactory(new JoinableTaskContext(synchronizationContext: SynchronizationContext.Current));
-
-        [Export]
-        public JoinableTaskContext TaskContext => TaskFactory.Context;
 
         [Export(typeof(CredentialsHandler))]
         public CredentialsHandler CredentialsHandler { get; } = new CredentialsHandler(OnHandleCredentials);

--- a/src/Guit/Guit.csproj
+++ b/src/Guit/Guit.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="LibGit2Sharp" Version="0.26.1" />
     <PackageReference Include="Microsoft.Alm.Authentication" Version="4.3.0" />
     <PackageReference Include="Merq.Core" Version="1.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.3.13" />
     <PackageReference Include="RxFree" Version="1.0.0-beta" />
     <PackageReference Include="System.Composition" Version="1.2.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />

--- a/src/Guit/Plugin/Changes/CommitCommand.cs
+++ b/src/Guit/Plugin/Changes/CommitCommand.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Guit.Events;
 using LibGit2Sharp;
 using Merq;
-using Microsoft.VisualStudio.Threading;
 using Terminal.Gui;
 using Git = LibGit2Sharp.Commands;
 
@@ -17,15 +16,15 @@ namespace Guit.Plugin.Changes
     public class CommitCommand : IMenuCommand
     {
         readonly IEventStream eventStream;
-        readonly JoinableTaskFactory jtf;
+        readonly MainThread mainThread;
         readonly Repository repository;
         readonly ChangesView changes;
 
         [ImportingConstructor]
-        public CommitCommand(IEventStream eventStream, JoinableTaskFactory jtf, Repository repository, ChangesView changes)
+        public CommitCommand(IEventStream eventStream, MainThread mainThread, Repository repository, ChangesView changes)
         {
             this.eventStream = eventStream;
-            this.jtf = jtf;
+            this.mainThread = mainThread;
             this.repository = repository;
             this.changes = changes;
         }
@@ -35,13 +34,7 @@ namespace Guit.Plugin.Changes
             if (changes.GetMarkedEntries().Any())
             {
                 var dialog = new CommitDialog();
-
-                var dialogResult = jtf.Run(async () =>
-                {
-                    await jtf.SwitchToMainThreadAsync();
-
-                    return dialog.ShowDialog();
-                });
+                var dialogResult = mainThread.Invoke(() => dialog.ShowDialog());
 
                 if (dialogResult == true)
                 {


### PR DESCRIPTION
The JTF adds complexity that is not worth it for the target app types
and the typical behaviors we have. In fact, it can introduce hard to
diagnose bugs like using Run() when you should do RunAsync, on others.

We instead provide a very simple abstraction over the main loop with
MainThread, which allows to efficiently call Invoke (by first checking
if invoke is required at all, since it's not needed if you're already
on the main thread) and added the capability of retrieving a result
from that execution too (i.e. to get a dialog result).

This is sufficient and much simpler than the alternative.