### PR TITLE
Fixed progress dialog and added minimal support

### DIFF
--- a/src/Guit.Core/MinimalProgressDialog.cs
+++ b/src/Guit.Core/MinimalProgressDialog.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using Terminal.Gui;
+
+namespace Guit
+{
+    class MinimalProgressDialog : Dialog
+    {
+        ProgressBar progressBar;
+
+        readonly List<string> entries = new List<string>();
+
+        public MinimalProgressDialog(string title)
+            : base(title, 0, 0)
+        {
+            InitilizeComponents();
+        }
+
+        void InitilizeComponents()
+        {
+            Width = 60;
+            Height = 6;
+
+            progressBar = new ProgressBar() { Y = 1 };
+
+            Add(progressBar);
+        }
+
+        public override bool ProcessKey(KeyEvent kb)
+        {
+            if ((kb.KeyValue == (int)Key.Enter && progressBar.Fraction == 1) || kb.KeyValue == (int)Key.Esc)
+            {
+                Running = false;
+                return false;
+            }
+
+            return base.ProcessKey(kb);
+        }
+
+        public void Report(float progress)
+        {
+            if (progress > progressBar.Fraction)
+                progressBar.Fraction = progress;
+        }
+    }
+}

--- a/src/Guit.Core/ProgressDialog.cs
+++ b/src/Guit.Core/ProgressDialog.cs
@@ -26,7 +26,8 @@ namespace Guit
                 CanFocus = false,
                 AllowsMarking = false,
                 Height = Dim.Fill() - 1,
-                Width = Dim.Fill()
+                Width = Dim.Fill() - 1,
+                X = 1, Y = 1
             };
 
             progressBar = new ProgressBar();


### PR DESCRIPTION
For commands that need minimal progress/feedback support
without showing any text we can show a minimal progress bar
in order to give the user some feedback about the execution
status.

The service already support the ability to automatically
change (or upgrade) to the full progress dialog if necessary

Minimal progress dialog will be dismissed automatically.