### PR TITLE
Use IRepository whenever possible

### DIFF
--- a/src/Guit/DefaultExports.cs
+++ b/src/Guit/DefaultExports.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Composition;
-using System.IO;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 using Microsoft.Alm.Authentication;

--- a/src/Guit/RepositoryProvider.cs
+++ b/src/Guit/RepositoryProvider.cs
@@ -26,5 +26,9 @@ namespace Guit
         [Export(typeof(ISingleton))]
         [Export]
         public Repository Repository { get; }
+
+        [Export(typeof(ISingleton))]
+        [Export]
+        public IRepository IRepository => Repository;
     }
 }

--- a/src/Plugins/Guit.Changes/CommitCommand.cs
+++ b/src/Plugins/Guit.Changes/CommitCommand.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Guit.Events;
 using LibGit2Sharp;
 using Merq;
-using Terminal.Gui;
 using Git = LibGit2Sharp.Commands;
 
 namespace Guit.Plugin.Changes
@@ -17,11 +16,11 @@ namespace Guit.Plugin.Changes
     {
         readonly IEventStream eventStream;
         readonly MainThread mainThread;
-        readonly Repository repository;
+        readonly IRepository repository;
         readonly ChangesView changes;
 
         [ImportingConstructor]
-        public CommitCommand(IEventStream eventStream, MainThread mainThread, Repository repository, ChangesView changes)
+        public CommitCommand(IEventStream eventStream, MainThread mainThread, IRepository repository, ChangesView changes)
         {
             this.eventStream = eventStream;
             this.mainThread = mainThread;

--- a/src/Plugins/Guit.Changes/RevertCommand.cs
+++ b/src/Plugins/Guit.Changes/RevertCommand.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
-using Terminal.Gui;
 using Git = LibGit2Sharp.Commands;
 
 namespace Guit.Plugin.Changes
@@ -13,11 +12,11 @@ namespace Guit.Plugin.Changes
     public class RevertCommand : IMenuCommand
     {
         readonly MainThread mainThread;
-        readonly Repository repository;
+        readonly IRepository repository;
         readonly ChangesView changes;
 
         [ImportingConstructor]
-        public RevertCommand(MainThread mainThread, Repository repository, ChangesView changes)
+        public RevertCommand(MainThread mainThread, IRepository repository, ChangesView changes)
         {
             this.mainThread = mainThread;
             this.repository = repository;

--- a/src/Plugins/Guit.Log/LogView.cs
+++ b/src/Plugins/Guit.Log/LogView.cs
@@ -12,13 +12,13 @@ namespace Guit.Plugin.Log
     [ContentView(nameof(Log), '3')]
     public class LogView : ContentView
     {
-        readonly Repository repository;
+        readonly IRepository repository;
 
         List<CommitEntry> commits = new List<CommitEntry>();
         readonly ListView view;
 
         [ImportingConstructor]
-        public LogView(Repository repository)
+        public LogView(IRepository repository)
             : base("Log")
         {
             this.repository = repository;

--- a/src/Plugins/Guit.Log/ResetCommand.cs
+++ b/src/Plugins/Guit.Log/ResetCommand.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
-using Terminal.Gui;
 
 namespace Guit.Plugin.Log
 {
@@ -11,11 +10,11 @@ namespace Guit.Plugin.Log
     public class ResetCommand : IMenuCommand
     {
         readonly MainThread mainThread;
-        readonly Repository repository;
+        readonly IRepository repository;
         readonly LogView log;
 
         [ImportingConstructor]
-        public ResetCommand(MainThread mainThread, Repository repository, LogView log)
+        public ResetCommand(MainThread mainThread, IRepository repository, LogView log)
         {
             this.mainThread = mainThread;
             this.repository = repository;

--- a/src/Plugins/Guit.Sync/FetchCommand.cs
+++ b/src/Plugins/Guit.Sync/FetchCommand.cs
@@ -6,7 +6,6 @@ using Guit.Events;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 using Merq;
-using Terminal.Gui;
 using Git = LibGit2Sharp.Commands;
 
 namespace Guit.Commands

--- a/src/Plugins/Guit.Sync/PullCommand.cs
+++ b/src/Plugins/Guit.Sync/PullCommand.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Guit.Sync.Properties;
 using LibGit2Sharp;
-using Terminal.Gui;
 
 namespace Guit.Plugin.Sync
 {
@@ -14,10 +13,10 @@ namespace Guit.Plugin.Sync
     public class PullCommand : IMenuCommand
     {
         readonly MainThread mainThread;
-        readonly Repository repository;
+        readonly IRepository repository;
 
         [ImportingConstructor]
-        public PullCommand(MainThread mainThread, Repository repository)
+        public PullCommand(MainThread mainThread, IRepository repository)
         {
             this.mainThread = mainThread;
             this.repository = repository;

--- a/src/Plugins/Guit.Sync/PushCommand.cs
+++ b/src/Plugins/Guit.Sync/PushCommand.cs
@@ -8,7 +8,6 @@ using Guit.Sync.Properties;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 using Merq;
-using Terminal.Gui;
 
 namespace Guit.Plugin.Sync
 {


### PR DESCRIPTION
Using the interface will allow us to provide more automatic behavior
down the road (i.e. filtering logs and changed files to what's in
the current directory, instead of everything from the repo root, or
automatically setting the credentials handler).

Some APIs, however, do require the `Repository` type (like `Commands.Fetch`)
in LibGit2Sharp, so we expose both for those cases.