### PR TITLE
Added ability to reload shell and plugins

### DIFF
--- a/src/Guit.Core/IShell.cs
+++ b/src/Guit.Core/IShell.cs
@@ -6,12 +6,17 @@ namespace Guit
     /// Allows commands to run main views, which cause the current main view 
     /// to be closed and the new one showed.
     /// </summary>
-    public interface IApp
+    public interface IShell
     {
         /// <summary>
         /// Gets the current view being shown
         /// </summary>
         ContentView? CurrentView { get; }
+
+        /// <summary>
+        /// Shuts down the main shell UI.
+        /// </summary>
+        void Shutdown();
 
         /// <summary>
         /// Runs the given main view as the top-level view in the app.

--- a/src/Guit/App.cs
+++ b/src/Guit/App.cs
@@ -1,126 +1,63 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Composition;
+using System.ComponentModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using System.Reflection;
-using Terminal.Gui;
-using LibGit2Sharp;
-using Merq;
 using Guit.Events;
+using Terminal.Gui;
 
 namespace Guit
 {
-    [Export]
-    [Export(typeof(IApp))]
-    [Shared]
-    class App : Toplevel, IApp
+    class App : Toplevel
     {
-        readonly ConcurrentDictionary<ContentView, string?> contexts = new ConcurrentDictionary<ContentView, string?>();
-        readonly ConcurrentDictionary<ContentView, ShellWindow> shellWindows = new ConcurrentDictionary<ContentView, ShellWindow>();
-
-        readonly Lazy<ContentView, MenuCommandMetadata> defaultView;
-        readonly IEnumerable<Lazy<ContentView, MenuCommandMetadata>> views;
-
-        readonly MainThread mainThread;
-        readonly Lazy<CommandService> commandService;
-        readonly IRepository repository;
-
-        [ImportingConstructor]
-        public App(
-            [ImportMany] IEnumerable<Lazy<ContentView, MenuCommandMetadata>> views,
-            MainThread mainThread,
-            Lazy<CommandService> commandService,
-            IEventStream eventStream,
-            IRepository repository)
+        private CompositionManager manager;
+        private Label spinner = new Label("Reloading plugins...")
         {
-            this.views = views
-                .OrderBy(x => x.Metadata.Order)
-                .ThenBy(x => x.Metadata.Key);
+            X = Pos.Center(),
+            Y = Pos.Center(),
+        };
 
-            defaultView = this.views.First();
-
-            this.mainThread = mainThread;
-            this.commandService = commandService;
-            this.repository = repository;
-
-            eventStream.Of<BranchChanged>().Subscribe(x =>
-                mainThread.Invoke(() =>
-                {
-                    if (CurrentView != null && shellWindows.TryGetValue(CurrentView, out var shellWindow))
-                        shellWindow.Refresh();
-                }));
+        public App(CompositionManager manager)
+        {
+            this.manager = manager;
+            Add(spinner);
         }
 
-        public ContentView? CurrentView { get; private set; }
-
-        public override bool ProcessHotKey(KeyEvent keyEvent)
+        public override void WillPresent()
         {
-            if (Application.Current is ShellWindow shellWindow)
-                commandService.Value.RunAsync(keyEvent.KeyValue, GetContext(shellWindow.Content));
-
-            return base.ProcessHotKey(keyEvent);
+            base.WillPresent();
+            RunShell();
         }
 
-        string? GetContext(ContentView? view) =>
-            view != null ? contexts.GetOrAdd(view, x => x.GetType().GetCustomAttribute<ContentViewAttribute>()?.Context) : default;
-
-        // Run the main window as soon as the app is presented.
-        public override void WillPresent() => RunAsync(defaultView.Value);
-
-        public Task RunAsync(ContentView view)
+        void RunShell()
         {
-            mainThread.Invoke(() =>
+            while (true)
             {
-                if (Application.Current is ShellWindow shellWindow)
-                    shellWindow.Running = false;
+                //var wait = new SpinWait();
+                //var task = Task.Run(() => manager.CreateComposition());
 
-                CurrentView = view;
+                //var chars = new[] { '◴', '◷', '◶', '◵' };
+                //var chars = new[] { '|', '/', '-', '\\' };
+                //var index = 0;
 
-                view.Refresh();
+                //while (!task.IsCompleted)
+                //{
+                //    wait.SpinOnce();
+                //    //if (index >= chars.Length)
+                //    //    index = 0;
+                //    // TODO: refresh spinner
+                //    //index++;
+                //}
 
-                shellWindow = shellWindows.GetOrAdd(view, x =>
-                    new ShellWindow(
-                        view.Title,
-                        view,
-                        Tuple.Create(0, 0, 0, 1),
-                        new CommandBar(commandService.Value, GetContext(view)),
-                        new RepoStatus(repository)
-                        ));
+                using (var composition = manager.CreateComposition())
+                {
+                    //Force all singletons to be instantiated.
+                    composition.GetExports<ISingleton>();
 
-                shellWindow.Refresh();
-
-                Application.Run(shellWindow);
-            });
-
-            return Task.CompletedTask;
-        }
-
-        public async Task RunNext()
-        {
-            var viewList = views.ToList();
-
-            var currentViewWithMetadata = viewList.FirstOrDefault(x => x.Metadata.Context == GetContext(CurrentView));
-
-            var targetIndex = viewList.IndexOf(currentViewWithMetadata) + 1;
-            if (targetIndex >= viewList.Count)
-                targetIndex = 0;
-
-            await RunAsync(viewList[targetIndex].Value);
-        }
-
-        public async Task RunPrevious()
-        {
-            var viewList = views.ToList();
-
-            var currentViewWithMetadata = viewList.FirstOrDefault(x => x.Metadata.Context == GetContext(CurrentView));
-
-            var targetIndex = viewList.IndexOf(currentViewWithMetadata) - 1;
-            if (targetIndex < 0)
-                targetIndex = viewList.Count - 1;
-
-            await RunAsync(viewList[targetIndex].Value);
+                    //Obtain our first exported value
+                    Application.Run(composition.GetExport<Shell>());
+                }
+            }
         }
     }
 }

--- a/src/Guit/CommandExports.cs
+++ b/src/Guit/CommandExports.cs
@@ -7,11 +7,11 @@ namespace Guit
     [Shared]
     class CommandExports
     {
-        readonly Lazy<IApp> app;
+        readonly Lazy<IShell> app;
         readonly MainThread mainThread;
 
         [ImportingConstructor]
-        public CommandExports(Lazy<IApp> app, MainThread mainThread)
+        public CommandExports(Lazy<IShell> app, MainThread mainThread)
         {
             this.app = app;
             this.mainThread = mainThread;

--- a/src/Guit/CommandService.cs
+++ b/src/Guit/CommandService.cs
@@ -20,7 +20,7 @@ namespace Guit
 
         [ImportingConstructor]
         public CommandService(
-            IApp app,
+            IShell app,
             MainThread mainThread,
             IEventStream eventStream,
             [ImportMany] IEnumerable<Lazy<IMenuCommand, MenuCommandMetadata>> commands,

--- a/src/Guit/CompositionManager.cs
+++ b/src/Guit/CompositionManager.cs
@@ -24,7 +24,7 @@ namespace Guit
             var discovery = new AttributedPartDiscovery(Resolver.DefaultInstance, true);
             var catalog = ComposableCatalog.Create(Resolver.DefaultInstance)
                 .AddParts(discovery.CreatePartsAsync(Assembly.GetExecutingAssembly()).Result)
-                .AddParts(discovery.CreatePartsAsync(typeof(IApp).Assembly).Result)
+                .AddParts(discovery.CreatePartsAsync(typeof(IShell).Assembly).Result)
                 .WithCompositionService();
 
             // Add parts from plugins

--- a/src/Guit/Guit.Plugin.csproj
+++ b/src/Guit/Guit.Plugin.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <PluginId>$PluginId$</PluginId>
+    <PluginVersion>$PluginVersion$</PluginVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="$(PluginId)" Version="$(PluginVersion)" />
@@ -17,6 +19,7 @@
     <WriteLinesToFile File="$(BaseIntermediateOutputPath)\ReferencePaths.txt"
                       Lines="@(ReferencePath -> '%(FullPath)')"
                       Condition="'%(ReferencePath.NuGetPackageId)' == '$(PluginId)'"
+                      WriteOnlyWhenDifferent="true"
                       Overwrite="true" />
   </Target>
 </Project>

--- a/src/Guit/MenuComandAdapter.cs
+++ b/src/Guit/MenuComandAdapter.cs
@@ -7,9 +7,9 @@ namespace Guit
     class MenuCommandAdapter : IMenuCommand
     {
         readonly Lazy<ContentView, MenuCommandMetadata> view;
-        readonly IApp app;
+        readonly IShell app;
 
-        public MenuCommandAdapter(Lazy<ContentView, MenuCommandMetadata> view, IApp app)
+        public MenuCommandAdapter(Lazy<ContentView, MenuCommandMetadata> view, IShell app)
         {
             this.view = view;
             this.app = app;

--- a/src/Guit/Plugins/PluginsCommand.cs
+++ b/src/Guit/Plugins/PluginsCommand.cs
@@ -13,7 +13,7 @@ namespace Guit
         readonly Func<Task> run;
 
         [ImportingConstructor]
-        public PluginsCommand(PluginsView view, IApp app) => run = () => app.RunAsync(view);
+        public PluginsCommand(PluginsView view, IShell app) => run = () => app.RunAsync(view);
 
         public Task ExecuteAsync(CancellationToken cancellation) => run();
     }

--- a/src/Guit/Plugins/PluginsView.cs
+++ b/src/Guit/Plugins/PluginsView.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Composition;
+using System.Security;
 using LibGit2Sharp;
 using Terminal.Gui;
 

--- a/src/Guit/Plugins/SavePluginsCommand.cs
+++ b/src/Guit/Plugins/SavePluginsCommand.cs
@@ -1,23 +1,24 @@
 ﻿using System.Composition;
+using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
-using Terminal.Gui;
 
 namespace Guit
 {
     [Shared]
-    [MenuCommand("Save", 's', "Plugins")]
+    [MenuCommand("Save", 's', "Plugins", ReportProgress = false)]
     public class SavePluginsCommand : IMenuCommand
     {
-        readonly IApp app;
+        readonly IShell app;
 
         [ImportingConstructor]
-        public SavePluginsCommand(IApp app) => this.app = app;
+        public SavePluginsCommand(IShell app) => this.app = app;
 
         public Task ExecuteAsync(CancellationToken cancellation)
         {
-            // TODO: stop app
-            //app.Stop();
+            // TODO: save selected plugins list.
+
+            app.Shutdown();
             return Task.CompletedTask;
         }
     }

--- a/src/Guit/Program.cs
+++ b/src/Guit/Program.cs
@@ -29,15 +29,7 @@ namespace Guit
                 var compositionManager = new CompositionManager(pluginManager);
 
                 Application.Init();
-
-                var composition = compositionManager.CreateComposition();
-                // Force all singletons to be instantiated.
-                composition.GetExports<ISingleton>();
-
-                // Obtain our first exported value
-                Application.Run(composition.GetExport<App>());
-
-                Console.ReadLine();
+                Application.Run(new App(compositionManager));
             }
             catch (Exception e)
             {

--- a/src/Guit/Shell.cs
+++ b/src/Guit/Shell.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Reflection;
+using Terminal.Gui;
+using System.Data;
+using System.Threading;
+using LibGit2Sharp;
+using Merq;
+using Guit.Events;
+
+namespace Guit
+{
+    [Export]
+    [Export(typeof(IShell))]
+    [Shared]
+    class Shell : Toplevel, IShell
+    {
+        readonly ConcurrentDictionary<ContentView, string?> contexts = new ConcurrentDictionary<ContentView, string?>();
+        readonly ConcurrentDictionary<ContentView, ShellWindow> shellWindows = new ConcurrentDictionary<ContentView, ShellWindow>();
+        readonly ConcurrentDictionary<ContentView, ManualResetEventSlim> runningViews = new ConcurrentDictionary<ContentView, ManualResetEventSlim>();
+        
+        readonly Lazy<ContentView, MenuCommandMetadata> defaultView;
+        readonly IEnumerable<Lazy<ContentView, MenuCommandMetadata>> views;
+
+        readonly MainThread mainThread;
+        readonly Lazy<CommandService> commandService;
+        readonly IRepository repository;
+
+        [ImportingConstructor]
+        public Shell(
+            [ImportMany] IEnumerable<Lazy<ContentView, MenuCommandMetadata>> views,
+            MainThread mainThread,
+            Lazy<CommandService> commandService,
+            IEventStream eventStream,
+            IRepository repository)
+        {
+            this.views = views
+                .OrderBy(x => x.Metadata.Order)
+                .ThenBy(x => x.Metadata.Key);
+
+            defaultView = this.views.First();
+
+            this.mainThread = mainThread;
+            this.commandService = commandService;
+            this.repository = repository;
+
+            eventStream.Of<BranchChanged>().Subscribe(x =>
+                mainThread.Invoke(() =>
+                {
+                    if (CurrentView != null && shellWindows.TryGetValue(CurrentView, out var shellWindow))
+                        shellWindow.Refresh();
+                }));
+        }
+
+        public ContentView? CurrentView { get; private set; }
+
+        public override bool ProcessHotKey(KeyEvent keyEvent)
+        {
+            if (Application.Current is ShellWindow shellWindow)
+                commandService.Value.RunAsync(keyEvent.KeyValue, GetContext(shellWindow.Content));
+
+            return base.ProcessHotKey(keyEvent);
+        }
+
+        string? GetContext(ContentView? view) =>
+            view != null ? contexts.GetOrAdd(view, x => x.GetType().GetCustomAttribute<ContentViewAttribute>()?.Context) : default;
+
+        // Run the main window as soon as the app is presented.
+        public override void WillPresent() => RunAsync(defaultView.Value);
+
+        ManualResetEventSlim exitEvent = new ManualResetEventSlim();
+
+        public void Run()
+        {
+            RunAsync(defaultView.Value);
+            exitEvent.Wait();
+        }
+
+        public Task RunAsync(ContentView view)
+        {
+            if (Application.Current is ShellWindow shellWindow)
+            {
+                // NOTE: we don't set the event at this point, since we 
+                // want the running to actually be stopped by the mainloop
+                // continuing from the previous Application.Run() for that 
+                // window, at which point, the event will be set when we know 
+                // for sure the mainloop for that window is no longer running.
+                // See bellow.
+                Application.MainLoop.AddTimeout(TimeSpan.Zero, _ => shellWindow.Running = false);
+                if (runningViews.TryGetValue(shellWindow.Content, out var running))
+                    running.Wait();
+            }
+
+            mainThread.Invoke(() =>
+            {
+                CurrentView = view;
+                view.Refresh();
+
+                var window = shellWindows.GetOrAdd(view, key =>
+                    new ShellWindow(
+                        key.Title,
+                        key,
+                        Tuple.Create(0, 0, 0, 1),
+                        new CommandBar(commandService.Value, GetContext(key)),
+                        new RepoStatus(repository)
+                        ));
+
+                var running = runningViews.GetOrAdd(view, _ => new ManualResetEventSlim());
+
+                running.Reset();
+                Application.Run(window);
+                running.Set();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        public async Task RunNext()
+        {
+            var viewList = views.ToList();
+
+            var currentViewWithMetadata = viewList.FirstOrDefault(x => x.Metadata.Context == GetContext(CurrentView));
+
+            var targetIndex = viewList.IndexOf(currentViewWithMetadata) + 1;
+            if (targetIndex >= viewList.Count)
+                targetIndex = 0;
+
+            await RunAsync(viewList[targetIndex].Value);
+        }
+
+        public async Task RunPrevious()
+        {
+            var viewList = views.ToList();
+
+            var currentViewWithMetadata = viewList.FirstOrDefault(x => x.Metadata.Context == GetContext(CurrentView));
+
+            var targetIndex = viewList.IndexOf(currentViewWithMetadata) - 1;
+            if (targetIndex < 0)
+                targetIndex = viewList.Count - 1;
+
+            await RunAsync(viewList[targetIndex].Value);
+        }
+
+        public void Shutdown()
+        {
+            Application.MainLoop.AddTimeout(TimeSpan.Zero, _ =>
+            {
+                foreach (var window in shellWindows.Values)
+                {
+                    window.Running = false;
+                }
+
+                return false;
+            });
+
+            var handles = runningViews.Values.Select(x => x.WaitHandle).ToArray();
+            while (!WaitHandle.WaitAll(handles, 100))
+            {
+                Thread.Sleep(50);
+            }
+
+            exitEvent.Set();
+
+            Application.MainLoop.AddTimeout(TimeSpan.Zero, _ => Running = false);
+        }
+    }
+}

--- a/src/Guit/ShellWindow.cs
+++ b/src/Guit/ShellWindow.cs
@@ -61,5 +61,7 @@ namespace Guit
 
             base.LayoutSubviews();
         }
+
+        public override string ToString() => Content.Title;
     }
 }


### PR DESCRIPTION
The existing App has been renamed Shell, and App now is responsible
for restarting the Shell, after unloading and reloading all plugins.

Progress reporting of the pluging reloading is missing since I had
many issues attempting to refresh the UI with some progress since
the App is running in the main thread already, and has to continue
to do so in order to block the console program, even while restarting
the shell.

Optimized the plugin manager so that it intelligently detects the
need to perform a nuget restore (i.e. plugin version has changed)
or even call MSBuild at all (i.e. plugin assembly list points to
files that all exist on disk).

Demo:

![RestartShell](https://user-images.githubusercontent.com/169707/66287775-600d9580-e8ad-11e9-92dc-b857d82979d9.gif)

(pending showing the actual list of plugins, and saving them, which is also pending https://github.com/libgit2/libgit2sharp/pulls)