### PR TITLE
Disable plugins view on release builds

### DIFF
--- a/src/Guit/Plugins/PluginsCommand.cs
+++ b/src/Guit/Plugins/PluginsCommand.cs
@@ -7,7 +7,9 @@ using Terminal.Gui;
 namespace Guit
 {
     [Shared]
+#if DEBUG
     [MenuCommand("Plugins", Key.F10)]
+#endif
     public class PluginsCommand : IMenuCommand
     {
         readonly Func<Task> run;


### PR DESCRIPTION
This means the view will only be visible when building locally, not when installing the tool from CI/nuget.